### PR TITLE
Fix `module.exports` :poop:

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,15 @@ by the poop emoji (poomoji).
 ```javascript
 const poopthis = require('poopthis')
 
-console.log(poopthis('What is the point of this node package?', 3))
+console.log(poopthis('What is the point of this node package?'))
 ```
+Output: :hankey: What is the point of this node package? :hankey:
 
+```javascript
+const poopthis = require('poopthis')
+
+console.log(poopthis.times('What is the point of this node package?', 3))
+```
 Output: :hankey: :hankey: :hankey: What is the point of this node package? :hankey: :hankey: :hankey:
 
 :ok_hand:

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = function (string) {
   return poop + ' ' + string + ' ' + poop
 }
 
-module.exports = function pooptimes (string, times) {
+module.exports.times = function pooptimes (string, times) {
   var string = string.trim()
   var poop = emoji.get('hankey')
   if (times === 0)


### PR DESCRIPTION
Before:
```js
> const poop = require('.')
> poop('^~^')
RangeError: Maximum call stack size exceeded
    at String.indexOf (native)
    at Object.get (/Users/matheus/dev/forks/poopthis/node_modules/node-emoji/lib/emoji.js:36:13)
    at pooptimes (/Users/matheus/dev/forks/poopthis/index.js:18:20)
    at pooptimes (/Users/matheus/dev/forks/poopthis/index.js:21:10)
    at pooptimes (/Users/matheus/dev/forks/poopthis/index.js:21:10)
    at pooptimes (/Users/matheus/dev/forks/poopthis/index.js:21:10)
    at pooptimes (/Users/matheus/dev/forks/poopthis/index.js:21:10)
    at pooptimes (/Users/matheus/dev/forks/poopthis/index.js:21:10)
    at pooptimes (/Users/matheus/dev/forks/poopthis/index.js:21:10)
    at pooptimes (/Users/matheus/dev/forks/poopthis/index.js:21:10)
```

After:
```js
> const p
> poop('^~^')
'💩 ^~^ 💩'
```